### PR TITLE
API Versioning

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    default_api_version: "2.0"
 
 services:
     # default configuration for services in *this* file

--- a/migrations/Version20240906141153.php
+++ b/migrations/Version20240906141153.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240906141153 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE product CHANGE description description LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE product CHANGE description description LONGTEXT NOT NULL');
+    }
+}

--- a/src/Controller/CustomerController.php
+++ b/src/Controller/CustomerController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Entity\User;
 use App\Repository\CustomerRepository;
 use App\Repository\UserRepository;
+use App\Service\VersioningService;
 use Doctrine\ORM\EntityManagerInterface;
 use JMS\Serializer\SerializationContext;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -24,6 +25,13 @@ use JMS\Serializer\SerializerInterface;
 
 class CustomerController extends AbstractController
 {
+    private VersioningService $versioningService;
+
+    public function __construct(VersioningService $versioningService)
+    {
+        $this->versioningService = $versioningService;
+    }
+
     #[Route('/api/users', name: 'app_customers_users_list', methods:['GET'])]
     #[IsGranted('ROLE_CUSTOMER', message: "Vous n'avez pas les droits pour accèder aux utilisateurs")]
     public function getCustomerUsers( 
@@ -50,7 +58,9 @@ class CustomerController extends AbstractController
             $item->tag('customerUsersCache');
             $customersUsersList = $customerRepository->findAllCustomerUsersWithPagination($page, $customerId, $limit);
            
+            $version = $this->versioningService->getVersion();
             $context = SerializationContext::create()->setGroups(['getCustomerUsers']);
+            $context->setVersion($version);
             return $serializer->serialize($customersUsersList, 'json', $context);
         });
         
@@ -84,7 +94,9 @@ class CustomerController extends AbstractController
             $item->tag('customerUsersDetailsCache');
             $user = $userRepository->find($id);
             
+            $version = $this->versioningService->getVersion();
             $context = SerializationContext::create()->setGroups(['getCustomerUsersDetails']);
+            $context->setVersion($version);
             return $serializer->serialize($user, 'json', $context);
         });
 

--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -6,9 +6,8 @@ use App\Repository\ProductRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation\Groups;
-use JMS\Serializer\Annotation as Serializer;
 use Hateoas\Configuration\Annotation as Hateoas;
-
+use JMS\Serializer\Annotation\Since;
 
 /**
  * @Hateoas\Relation(
@@ -33,8 +32,9 @@ class Product
     #[Groups(["getProducts"])]
     private ?string $name = null;
 
-    #[ORM\Column(type: Types::TEXT)]
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
     #[Groups(["getProducts"])]
+    #[Since("2.0")]
     private ?string $description = null;
 
     #[ORM\Column(length: 255)]

--- a/src/Service/VersioningService.php
+++ b/src/Service/VersioningService.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Service;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * A Symfony service to retrieve the version contained in the "Accept" field of the HTTP request.
+ */
+class VersioningService
+{
+    private RequestStack $requestStack;
+    private string $defaultVersion;
+
+    /**
+     * Constructor allowing to retrieve the current request (to extract the "Accept" field from the header)
+     * as well as the ParameterBagInterface to get the default version from the configuration file.
+     *
+     * @param RequestStack $requestStack
+     * @param ParameterBagInterface $params
+     */
+    public function __construct(RequestStack $requestStack, ParameterBagInterface $params)
+    {
+        $this->requestStack = $requestStack;
+        $this->defaultVersion = $params->get('default_api_version');
+    }
+
+    /**
+     * Retrieve the version sent in the "Accept" header of the HTTP request.
+     *
+     * @return string The version number. By default, the returned version is the one defined in the services.yaml configuration file: "default_api_version".
+     */
+    public function getVersion(): string
+    {  
+        $version = $this->defaultVersion;
+
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request === null) {
+            // If there is no current request, return the default version
+            return $version;
+        }
+
+        $accept = $request->headers->get('Accept');
+        if ($accept === null) {
+            // If 'Accept' header is missing, return the default version
+            return $version;
+        }
+
+        // Retrieve the version number from the Accept string:
+        // example "application/json; test=bidule; version=2.0" => 2.0
+        $headers = explode(';', $accept);
+
+        foreach ($headers as $header) {
+            $header = trim($header); // Trim any extra spaces
+            if (strpos($header, 'version=') === 0) {
+                $version = substr($header, strlen('version='));
+                break;
+            }
+        }
+
+        return $version;
+    }
+}


### PR DESCRIPTION
#18 
- use `#[Since("2.0")]` with `use JMS\Serializer\Annotation\Since;` to tell that "description" field is present on the version 2.0 into Product Entity
- create a service `VersioningService.php` to be able to read version as a parameter in the request (Accept)
- add `$this->versioningService->getVersion();`  and `$context->setVersion($version);` in the controller
- edit `services.yaml` to tell the API default version